### PR TITLE
Add: Sorting by job posting date. 

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
                 <option value="title">Title</option>
                 <option value="location">Location</option>
                 <option value="ats">ATS</option>
+                <option value="posted">Posted Date</option>
             </select>
             <button id="mobile-sort-dir" class="btn btn-sm btn-outline-secondary">
                 A-Z
@@ -214,12 +215,13 @@
                             <th>Salary</th>
                             <th>ATS</th>
                             <th>Apply</th>
+                            <th>Posted</th>
                             <th>Actions</th>
                         </tr>
                     </thead>
                     <tbody id="jobs-body">
                         <tr>
-                            <td colspan="7" class="text-center">No jobs found</td>
+                            <td colspan="8" class="text-center">No jobs found</td>
                         </tr>
                     </tbody>
                 </table>

--- a/js/app.js
+++ b/js/app.js
@@ -151,8 +151,9 @@ class JobBoardApp {
 
     // ── URL State ────────────────────────────────────────────
     loadFromURL() {
-        const { hasFilters, page } = loadFromURL();
+        const { hasFilters, page, sortKey, sortDir } = loadFromURL();
         this.currentPage = page;
+        if (sortKey) this.sortState = { key: sortKey, direction: sortDir };
         if (hasFilters) this.applyFilters();
     }
 

--- a/js/columns.js
+++ b/js/columns.js
@@ -53,6 +53,22 @@ export function createColumns() {
             }
         },
         {
+            key: 'posted',
+            label: 'Posted',
+            sortable: true,
+            render: job => {
+                const raw = job.updated_at || job.first_seen;
+                if (!raw) return '<span class="text-muted">—</span>';
+                const d = new Date(raw);
+                if (isNaN(d.getTime())) return '<span class="text-muted">—</span>';
+                const days = Math.floor((Date.now() - d) / 86400000);
+                if (days === 0) return 'Today';
+                if (days === 1) return 'Yesterday';
+                if (days < 30) return `${days}d ago`;
+                return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+            }
+        },
+        {
             key: 'actions',
             label: 'Actions',
             sortable: false,

--- a/js/renderer.js
+++ b/js/renderer.js
@@ -28,7 +28,7 @@ export function render(app) {
     tbody.innerHTML = '';
 
     if (pageJobs.length === 0) {
-        tbody.innerHTML = '<tr><td colspan="7" class="text-center">No jobs found</td></tr>';
+        tbody.innerHTML = `<tr><td colspan="${app.columns.length}" class="text-center">No jobs found</td></tr>`;
         updatePagination(app.currentPage, 1, app.filteredJobs.length);
         updateSortIndicators(app.columns, app.sortState);
         return;

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -34,6 +34,16 @@ export function applySorting(jobs, sortState) {
             bVal = bVal || b.company_slug || '';
         }
 
+        // Date sort — ISO strings compare lexicographically; nulls always last
+        if (key === 'posted') {
+            const aRaw = a.updated_at || a.first_seen || null;
+            const bRaw = b.updated_at || b.first_seen || null;
+            if (!aRaw && !bRaw) return 0;
+            if (!aRaw) return 1;
+            if (!bRaw) return -1;
+            return (aRaw < bRaw ? -1 : aRaw > bRaw ? 1 : 0) * multiplier;
+        }
+
         aVal = aVal.toString().toLowerCase();
         bVal = bVal.toString().toLowerCase();
 

--- a/js/url_state.js
+++ b/js/url_state.js
@@ -67,5 +67,8 @@ export function loadFromURL() {
 
     const hasFilters = !!(title || company || location || salary || remote || status || ats || skillLevel || exclude || include);
 
-    return { hasFilters, page };
+    const sortKey = params.get('sort_key') || null;
+    const sortDir = params.get('sort_dir') || 'asc';
+
+    return { hasFilters, page, sortKey, sortDir };
 }

--- a/scripts/merge_data.py
+++ b/scripts/merge_data.py
@@ -99,10 +99,15 @@ def merge_job_data():
     if stale_count > 0:
         print(f"Dropped {stale_count:,} stale jobs (>30 days old)")
     
-    # New scrape always wins on duplicates
+    # New scrape always wins on duplicates; preserve first_seen across runs
     for job in new_jobs:
         key = get_dedup_key(job)
         if key:
+            existing = merged.get(key)
+            if existing:
+                job["first_seen"] = existing.get("first_seen") or existing.get("scraped_at")
+            else:
+                job["first_seen"] = job.get("scraped_at")
             merged[key] = job
     
     final_jobs = list(merged.values())

--- a/scripts/scraper.py
+++ b/scripts/scraper.py
@@ -7,7 +7,7 @@ import os
 import gzip
 import argparse
 import xml.etree.ElementTree as ET
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from urllib.parse import unquote
 from geolocation import build_lookup, lookup_location
@@ -189,7 +189,7 @@ def fetch_company_jobs_ashby(slug):
         payload = {
             "operationName": "ApiJobBoardWithTeams",
             "variables": {"organizationHostedJobsPageName": slug},
-            "query": "query ApiJobBoardWithTeams($organizationHostedJobsPageName: String!) { jobBoard: jobBoardWithTeams(organizationHostedJobsPageName: $organizationHostedJobsPageName) { jobPostings { id title locationName } } }",
+            "query": "query ApiJobBoardWithTeams($organizationHostedJobsPageName: String!) { jobBoard: jobBoardWithTeams(organizationHostedJobsPageName: $organizationHostedJobsPageName) { jobPostings { id title locationName publishedAt } } }",
         }
         headers = {
             "Content-Type": "application/json",
@@ -235,6 +235,7 @@ def fetch_company_jobs_ashby(slug):
                         "title": job.get("title", ""),
                         "location": job.get("locationName", "Not specified")[:50],
                         "url": f"https://jobs.ashbyhq.com/{slug}/{job.get('id')}",
+                        "updated_at": job.get("publishedAt"),
                         "is_recruiter": is_recruiter_company(slug),
                         "ats": "Ashby",
                         "skill_level": job_tier_classification(job.get("title", "")),
@@ -369,6 +370,26 @@ def fetch_company_jobs_lever(slug):
     return slug, [], None
 
 
+def _parse_workday_posted_on(text):
+    """Convert Workday's relative string (e.g. 'Posted 2 Days Ago') to an ISO date."""
+    if not text or not isinstance(text, str):
+        return None
+    t = text.strip().lower()
+    today = datetime.now(timezone.utc).date()
+    if "today" in t:
+        return today.isoformat()
+    m = re.search(r'(\d+)\s+day', t)
+    if m:
+        return (today - timedelta(days=int(m.group(1)))).isoformat()
+    m = re.search(r'(\d+)\s+week', t)
+    if m:
+        return (today - timedelta(weeks=int(m.group(1)))).isoformat()
+    m = re.search(r'(\d+)\s+month', t)
+    if m:
+        return (today - timedelta(days=int(m.group(1)) * 30)).isoformat()
+    return None
+
+
 def fetch_company_jobs_workday(slug):
     """
     slug format: "company|wd#|site_id" e.g. "kohls|wd1|kohlscareers"
@@ -450,6 +471,7 @@ def fetch_company_jobs_workday(slug):
                         "remote": remote,
                         "coords": coords,
                         "url": f"{base_url}/{site_id}{job_path}",
+                        "updated_at": _parse_workday_posted_on(job.get("postedOn")),
                         "is_recruiter": is_recruiter_company(company),
                         "ats": "Workday",
                         "skill_level": job_tier_classification(job.get("title", "")),
@@ -497,8 +519,11 @@ def fetch_company_jobs_icims(slug):
         ns = {"s": "http://www.sitemaps.org/schemas/sitemap/0.9"}
 
         normalized = []
-        for loc in root.findall(".//s:url/s:loc", ns):
-            job_url = loc.text.strip() if loc.text else ""
+        for url_el in root.findall(".//s:url", ns):
+            loc_el = url_el.find("s:loc", ns)
+            if not loc_el:
+                continue
+            job_url = loc_el.text.strip() if loc_el.text else ""
             if (
                 not job_url
                 or "/jobs/" not in job_url
@@ -512,7 +537,10 @@ def fetch_company_jobs_icims(slug):
                 title = unquote(parts[1]).replace("-", " ").strip().title()
             else:
                 continue
-            
+
+            lastmod_el = url_el.find("s:lastmod", ns)
+            updated_at = lastmod_el.text.strip() if lastmod_el is not None and lastmod_el.text else None
+
             remote, coords = False, None
             normalized.append(
                 {
@@ -523,6 +551,7 @@ def fetch_company_jobs_icims(slug):
                     "remote": remote,
                     "coords": coords,
                     "url": job_url,
+                    "updated_at": updated_at,
                     "is_recruiter": is_recruiter_company(slug),
                     "ats": "iCIMS",
                     "skill_level": job_tier_classification(title),
@@ -811,7 +840,8 @@ def save_results(all_companies, active_companies, all_jobs):
         "scraped_at",
         "remote",
         "coords",
-        "salary"
+        "salary",
+        "updated_at",
     }
 
     slim_jobs = [

--- a/scripts/tests/test_suite/test_dates.py
+++ b/scripts/tests/test_suite/test_dates.py
@@ -1,0 +1,276 @@
+"""
+Tests for the date-sorting feature:
+  1. updated_at field — verifies each ATS scraper extracts a date where expected.
+  2. first_seen logic  — unit tests the merge-loop logic with synthetic data (no I/O).
+  3. _parse_workday_posted_on — unit tests the Workday relative-date parser.
+"""
+
+import sys
+import os
+from pathlib import Path
+from datetime import datetime, date, timedelta, timezone
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from scraper import (
+    fetch_company_jobs_greenhouse,
+    fetch_company_jobs_ashby,
+    fetch_company_jobs_icims,
+    fetch_company_jobs_workday,
+    _parse_workday_posted_on,
+)
+from merge_data import get_dedup_key
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+FETCH_LIMIT = 20   # max jobs to inspect per ATS
+
+# (fetch_fn, sample_slugs, must_have_dates)
+# must_have_dates=True  → FAIL if 0 jobs have updated_at
+# must_have_dates=False → WARN only (field is best-effort for this ATS)
+ATS_SAMPLES = {
+    "Greenhouse": (fetch_company_jobs_greenhouse, ["accenturefederalservices", "canonical"],                    True),
+    "Ashby":      (fetch_company_jobs_ashby,      ["confluent", "zip"],                                        False),
+    "iCIMS":      (fetch_company_jobs_icims,      ["orange", "libertymutual"],                                 False),
+    "Workday":    (fetch_company_jobs_workday,    ["kohls|wd1|kohlscareers", "2020companies|wd1|external_careers"], False),
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def collect_jobs(fetch_fn, slugs, limit):
+    jobs = []
+    for slug in slugs:
+        try:
+            _, batch, _ = fetch_fn(slug)
+        except Exception as e:
+            print(f"    fetch failed for {slug}: {e}")
+            continue
+        jobs.extend(batch)
+        if len(jobs) >= limit:
+            break
+    return jobs[:limit]
+
+
+def check_updated_at(name, fetch_fn, slugs, must_have_dates):
+    """Fetch sample jobs and report updated_at coverage."""
+    jobs = collect_jobs(fetch_fn, slugs, FETCH_LIMIT)
+    if not jobs:
+        return name, 0, 0, "NO_JOBS"
+
+    with_date = [j for j in jobs if j.get("updated_at")]
+    total = len(jobs)
+    count = len(with_date)
+
+    # Validate format for any dates we did get
+    bad_format = []
+    for j in with_date:
+        raw = j["updated_at"]
+        try:
+            datetime.fromisoformat(str(raw).replace("Z", "+00:00"))
+        except (ValueError, TypeError):
+            bad_format.append(raw)
+
+    if bad_format:
+        return name, count, total, f"BAD_FORMAT ({bad_format[0]!r})"
+
+    if count == 0 and must_have_dates:
+        return name, count, total, "MISSING"
+
+    if count == 0:
+        return name, count, total, "NONE (expected — field is best-effort)"
+
+    return name, count, total, "OK"
+
+
+# ── Unit tests: first_seen merge logic ────────────────────────────────────────
+
+def _run_merge_logic(existing_jobs, new_jobs):
+    """Replicate the merge loop from merge_data.py for unit testing."""
+    merged = {get_dedup_key(j): j for j in existing_jobs if get_dedup_key(j)}
+
+    for job in new_jobs:
+        key = get_dedup_key(job)
+        if key:
+            existing = merged.get(key)
+            if existing:
+                job["first_seen"] = existing.get("first_seen") or existing.get("scraped_at")
+            else:
+                job["first_seen"] = job.get("scraped_at")
+            merged[key] = job
+
+    return merged
+
+
+def _job(url, scraped_at=None, first_seen=None, ats="Greenhouse"):
+    j = {"url": url, "ats": ats, "title": "Eng", "company": "acme"}
+    if scraped_at:
+        j["scraped_at"] = scraped_at
+    if first_seen:
+        j["first_seen"] = first_seen
+    return j
+
+
+def test_first_seen_new_job():
+    """A brand-new job gets first_seen = its own scraped_at."""
+    new = [_job("https://example.com/1", scraped_at="2025-01-10T00:00:00Z")]
+    result = _run_merge_logic(existing_jobs=[], new_jobs=new)
+    job = result["https://example.com/1"]
+    assert job["first_seen"] == "2025-01-10T00:00:00Z", (
+        f"expected 2025-01-10T00:00:00Z, got {job['first_seen']!r}"
+    )
+
+
+def test_first_seen_preserved_on_rescrape():
+    """Re-scraping a known job must NOT overwrite first_seen."""
+    existing = [_job("https://example.com/2",
+                     scraped_at="2025-01-01T00:00:00Z",
+                     first_seen="2025-01-01T00:00:00Z")]
+    new      = [_job("https://example.com/2", scraped_at="2025-02-01T00:00:00Z")]
+    result = _run_merge_logic(existing, new)
+    job = result["https://example.com/2"]
+    assert job["first_seen"] == "2025-01-01T00:00:00Z", (
+        f"first_seen should not change on rescrape, got {job['first_seen']!r}"
+    )
+
+
+def test_first_seen_seeded_from_scraped_at_when_missing():
+    """Existing job that pre-dates this feature (no first_seen) gets seeded
+    from scraped_at on the next merge run."""
+    existing = [_job("https://example.com/3", scraped_at="2024-12-01T00:00:00Z")]
+    new      = [_job("https://example.com/3", scraped_at="2025-01-15T00:00:00Z")]
+    result = _run_merge_logic(existing, new)
+    job = result["https://example.com/3"]
+    assert job["first_seen"] == "2024-12-01T00:00:00Z", (
+        f"first_seen should be seeded from old scraped_at, got {job['first_seen']!r}"
+    )
+
+
+def test_first_seen_independent_jobs():
+    """Two different URLs each get their own first_seen independently."""
+    new = [
+        _job("https://example.com/a", scraped_at="2025-03-01T00:00:00Z"),
+        _job("https://example.com/b", scraped_at="2025-03-02T00:00:00Z"),
+    ]
+    result = _run_merge_logic(existing_jobs=[], new_jobs=new)
+    assert result["https://example.com/a"]["first_seen"] == "2025-03-01T00:00:00Z"
+    assert result["https://example.com/b"]["first_seen"] == "2025-03-02T00:00:00Z"
+
+
+def test_first_seen_no_scraped_at():
+    """Job with no scraped_at gets first_seen=None rather than crashing."""
+    new = [_job("https://example.com/noscrape")]
+    result = _run_merge_logic(existing_jobs=[], new_jobs=new)
+    job = result["https://example.com/noscrape"]
+    assert "first_seen" in job, "first_seen key should always be set"
+    assert job["first_seen"] is None
+
+
+# ── Unit tests: Workday posted-on parser ──────────────────────────────────────
+
+def test_workday_parse_today():
+    result = _parse_workday_posted_on("Posted Today")
+    assert result == date.today().isoformat(), f"got {result!r}"
+
+
+def test_workday_parse_days():
+    result = _parse_workday_posted_on("Posted 2 Days Ago")
+    expected = (date.today() - timedelta(days=2)).isoformat()
+    assert result == expected, f"got {result!r}"
+
+
+def test_workday_parse_weeks():
+    result = _parse_workday_posted_on("Posted 1 Week Ago")
+    expected = (date.today() - timedelta(weeks=1)).isoformat()
+    assert result == expected, f"got {result!r}"
+
+
+def test_workday_parse_months():
+    result = _parse_workday_posted_on("Posted 2 Months Ago")
+    expected = (date.today() - timedelta(days=60)).isoformat()
+    assert result == expected, f"got {result!r}"
+
+
+def test_workday_parse_none():
+    assert _parse_workday_posted_on(None) is None
+    assert _parse_workday_posted_on("") is None
+    assert _parse_workday_posted_on("some unknown string") is None
+
+
+def test_workday_parse_returns_iso():
+    """Result must be a valid ISO date string parseable by datetime."""
+    result = _parse_workday_posted_on("Posted 5 Days Ago")
+    assert result is not None
+    datetime.fromisoformat(result)   # raises if not valid ISO
+
+
+def run_unit_tests():
+    tests = [
+        test_first_seen_new_job,
+        test_first_seen_preserved_on_rescrape,
+        test_first_seen_seeded_from_scraped_at_when_missing,
+        test_first_seen_independent_jobs,
+        test_first_seen_no_scraped_at,
+        test_workday_parse_today,
+        test_workday_parse_days,
+        test_workday_parse_weeks,
+        test_workday_parse_months,
+        test_workday_parse_none,
+        test_workday_parse_returns_iso,
+    ]
+    passed, failed = 0, []
+    for t in tests:
+        try:
+            t()
+            print(f"  PASS  {t.__name__}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  FAIL  {t.__name__}: {e}")
+            failed.append(t.__name__)
+        except Exception as e:
+            print(f"  ERROR {t.__name__}: {e}")
+            failed.append(t.__name__)
+    return passed, failed
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+def main():
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    summary_lines = []
+    failures = []
+
+    # 1. Unit tests (no network)
+    print("── first_seen merge logic (unit tests) ──")
+    passed, unit_failures = run_unit_tests()
+    unit_line = f"first_seen unit tests: {passed} passed, {len(unit_failures)} failed"
+    print(unit_line)
+    summary_lines.append(unit_line)
+    failures.extend(unit_failures)
+    print()
+
+    # 2. Network tests — updated_at field coverage per ATS
+    print("── updated_at field coverage (network) ──")
+    for name, (fetch_fn, slugs, must_have_dates) in ATS_SAMPLES.items():
+        name, count, total, status = check_updated_at(name, fetch_fn, slugs, must_have_dates)
+        coverage = f"{count}/{total}" if total else "0/0"
+        line = f"{name:12} updated_at: {coverage:6}  -> {status}"
+        print(line)
+        summary_lines.append(line)
+        if status in ("MISSING", "BAD_FORMAT", "NO_JOBS") and must_have_dates:
+            failures.append(name)
+
+    if summary_path:
+        with open(summary_path, "a") as f:
+            f.write("\n## Date Field Tests\n")
+            f.write("\n".join(summary_lines) + "\n")
+
+    if failures:
+        alert = f"\n[ALERT] date field failures: {', '.join(failures)}"
+        print(alert)
+        sys.exit(1)
+
+    print("\nAll date field checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_suite/test_dates_merge.py
+++ b/scripts/tests/test_suite/test_dates_merge.py
@@ -1,0 +1,9 @@
+# Check updated_at coverage in the raw scrape output (before merge)
+import json
+with open("scripts/output/all_jobs.json") as f:
+    jobs = json.load(f)
+
+from collections import Counter
+coverage = Counter((j["ats"], bool(j.get("updated_at"))) for j in jobs)
+for (ats, has_date), count in sorted(coverage.items()):
+    print(f"{ats:12} updated_at={'yes' if has_date else 'no ':3}: {count:,}")


### PR DESCRIPTION
Introduced an option to sort the results by the date. 

- Extracts post dates from Greenhouse (updated_at), Workday (postedOn parsed from relative strings), and iCIMS (<lastmod>); adds first_seen tracking in the merge pipeline as a universal fallback for ATSes without a date field. 

- Adds a sortable "Posted" column to the frontend showing relative dates, fixes the existing bug where sort state was written to the URL but never restored on page load, and adds unit + network tests for the new date logic. 